### PR TITLE
fix: update endpoint for the tzkt 1.16 release, /events gives a 404 now

### DIFF
--- a/src/ctrl.ts
+++ b/src/ctrl.ts
@@ -94,7 +94,7 @@ async function handleTimedoutOffersAndListings(max = 50) {
 }
 
 export async function run() {
-  const connection = new HubConnectionBuilder().withUrl(`${config.tzktApiUrl}/events`).build();
+  const connection = new HubConnectionBuilder().withUrl(`${config.tzktApiUrl}/ws`).build();
   const workerUtils = await getWorkerUtils();
 
   async function init() {


### PR DESCRIPTION
Otherwise the ctrl container exists with the following error:

`FailedToNegotiateWithServerError: Failed to complete negotiation with the server: Error: Not Found: Status code '404' Either this is not a SignalR endpoint or there is a proxy blocking the connection.`

